### PR TITLE
Add Java Jackson impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ It uses [binary search](https://en.wikipedia.org/wiki/Binary_search_algorithm) t
 On my machine (Ubuntu Linux 4.10.0-35-generic SMP x86_64 with 8Gb RAM, 8.4 MB maximum stack size),
 I found the following results, sorted from worst to best:
 
-language   | json library                                                | nesting level | file size     | notes                         |
----------- | ----------------------------------------------------------- | ------------- | ------------- | ----------------------------- |
-ruby       | [json](https://rubygems.org/gems/json/versions/1.8.3)       | 101           | 202 bytes     |
-rust       | [serde_json](https://docs.serde.rs/serde_json/)             | 128           | 256 bytes     |
-php        | `json_decode`                                               | 512           | 1024 bytes    | maximum depth is configurable |
-python3    | [json](https://docs.python.org/3/library/json.html)         | 994           | 2.0 KB        | without sys.setrecursionlimit
-C          | [jansson](https://jansson.readthedocs.io/)                  | 2049          | 4.0 KB        | 
-java       | [Gson](https://github.com/google/gson)                      | 5670          | 11.3 KB       |
-javascript | `JSON.parse`                                               | 5713          | 11.4 KB       |
-C++        | [nlohmann::json](https://github.com/nlohmann/json)          | 13787         | 27.6 KB       | segfault
-ruby       | [Oj](https://github.com/ohler55/oj)                         | ∞             | ∞             |
-Haskell    | [Aeson](https://hackage.haskell.org/package/aeson)          | ∞             | ∞             | available RAM is the only limit
-
+language        | json library                                                | nesting level | file size     | notes                         |
+----------------| ----------------------------------------------------------- | ------------- | ------------- | ----------------------------- |
+ruby            | [json](https://rubygems.org/gems/json/versions/1.8.3)       | 101           | 202 bytes     |
+rust            | [serde_json](https://docs.serde.rs/serde_json/)             | 128           | 256 bytes     |
+php             | `json_decode`                                               | 512           | 1024 bytes    | maximum depth is configurable |
+python3         | [json](https://docs.python.org/3/library/json.html)         | 994           | 2.0 KB        | without sys.setrecursionlimit
+C               | [jansson](https://jansson.readthedocs.io/)                  | 2049          | 4.0 KB        | 
+java - gson     | [Gson](https://github.com/google/gson)                      | 5670          | 11.3 KB       |
+javascript      | `JSON.parse`                                                | 5713          | 11.4 KB       |
+java - jackson  | [Jackson](https://github.com/FasterXML/jackson-core)        | 6373          | 13   KB       |
+C++             | [nlohmann::json](https://github.com/nlohmann/json)          | 13787         | 27.6 KB       | segfault
+ruby            | [Oj](https://github.com/ohler55/oj)                         | ∞             | ∞             |
+Haskell         | [Aeson](https://hackage.haskell.org/package/aeson)          | ∞             | ∞             | available RAM is the only limit
 
 ## Remarks
 

--- a/parser-java-jackson/pom.xml
+++ b/parser-java-jackson/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.lovasoa.jsonlimits</groupId>
+    <artifactId>bad-parser-jackson</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>com.github.lovasoa.jsonlimits.JacksonJavaParser</Main-Class>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/parser-java-jackson/src/main/java/com/github/lovasoa/jsonlimits/JacksonJavaParser.java
+++ b/parser-java-jackson/src/main/java/com/github/lovasoa/jsonlimits/JacksonJavaParser.java
@@ -1,0 +1,21 @@
+package com.github.lovasoa.jsonlimits;
+
+import java.util.Objects;
+import java.util.Scanner;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JacksonJavaParser {
+
+    private static final Scanner SIN = new Scanner(System.in);
+
+    public static void main(String[] args) throws JsonProcessingException {
+        String fullInput = SIN.next();
+        System.out.println("Full input: " + fullInput);
+        JsonNode jsonTree = new ObjectMapper().readTree(fullInput);
+        Objects.requireNonNull(jsonTree);
+    }
+
+}

--- a/test_java_jackson.sh
+++ b/test_java_jackson.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Assumes maven on path configured with Java 11+
+mvn -f parser-java-jackson/pom.xml clean install -DskipTests
+
+./test_parser.sh "$JAVA_HOME"/bin/java -jar parser-java-jackson/target/bad-parser-jackson-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Jackson is actually at least as popular as Gson. A bit more entreprise-y but performed decently.

The number seems to not be quite set but rather hover around 6200. Probably can be optimized but you said "default settings" so yeah.

The formatting change on the readme is mostly obsession with consistent indentation but feel free to amend it ofc.