### PR TITLE
Correct references to JSON specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,21 @@ It uses [binary search](https://en.wikipedia.org/wiki/Binary_search_algorithm) t
 On my machine (Ubuntu Linux 4.10.0-35-generic SMP x86_64 with 8Gb RAM, 8.4 MB maximum stack size),
 I found the following results, sorted from least nesting to most nesting:
 
-language   | json library                                                | nesting level | file size     | notes                         |
----------- | ----------------------------------------------------------- | ------------- | ------------- | ----------------------------- |
-ruby       | [json](https://rubygems.org/gems/json/versions/1.8.3)       | 101           | 202 bytes     |
-rust       | [serde_json](https://docs.serde.rs/serde_json/)             | 128           | 256 bytes     |
-php        | `json_decode`                                               | 512           | 1024 bytes    | maximum depth is configurable |
-python3    | [json](https://docs.python.org/3/library/json.html)         | 994           | 2.0 KB        | without sys.setrecursionlimit
-C          | [jansson](https://jansson.readthedocs.io/)                  | 2049          | 4.0 KB        | 
-java       | [Gson](https://github.com/google/gson)                      | 5670          | 11.3 KB       |
-javascript | `JSON.parse`                                               | 5713          | 11.4 KB       |
-C++        | [nlohmann::json](https://github.com/nlohmann/json)          | 13787         | 27.6 KB       | segfault
-Nim        | [json](https://nim-lang.org/docs/json.html)                 | 100000        | 200 KB        | w/ `-d:release`
-go         | `encoding/json`                                             | 2581101       | 5.0 MiB       | goroutine stack exceeds 1000000000-byte limit
-ruby       | [Oj](https://github.com/ohler55/oj)                         | ∞             | ∞             |
-Haskell    | [Aeson](https://hackage.haskell.org/package/aeson)          | ∞             | ∞             | available RAM is the only limit
+language        | json library                                                | nesting level | file size     | notes                         |
+----------------| ----------------------------------------------------------- | ------------- | ------------- | ----------------------------- |
+ruby            | [json](https://rubygems.org/gems/json/versions/1.8.3)       | 101           | 202 bytes     |
+rust            | [serde_json](https://docs.serde.rs/serde_json/)             | 128           | 256 bytes     |
+php             | `json_decode`                                               | 512           | 1024 bytes    | maximum depth is configurable |
+python3         | [json](https://docs.python.org/3/library/json.html)         | 994           | 2.0 KB        | without sys.setrecursionlimit
+C               | [jansson](https://jansson.readthedocs.io/)                  | 2049          | 4.0 KB        | 
+java - gson     | [Gson](https://github.com/google/gson)                      | 5670          | 11.3 KB       |
+javascript      | `JSON.parse`                                                | 5713          | 11.4 KB       |
+java - jackson  | [Jackson](https://github.com/FasterXML/jackson-core)        | 6373          | 13   KB       |
+C++             | [nlohmann::json](https://github.com/nlohmann/json)          | 13787         | 27.6 KB       | segfault
+Nim             | [json](https://nim-lang.org/docs/json.html)                 | 100000        | 200 KB        | w/ `-d:release`
+go              | `encoding/json`                                             | 2581101       | 5.0 MiB       | goroutine stack exceeds 1000000000-byte limit
+ruby            | [Oj](https://github.com/ohler55/oj)                         | ∞             | ∞             |
+Haskell         | [Aeson](https://hackage.haskell.org/package/aeson)          | ∞             | ∞             | available RAM is the only limit
 
 
 ## Remarks

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# Bad JSON parsers
+# Nesting levels for JSON parsers
 [![Build Status](https://travis-ci.org/lovasoa/bad_json_parsers.svg?branch=master)](https://travis-ci.org/lovasoa/bad_json_parsers)
 
-Exposing problems in json parsers of several programming languages.
-The name of this repository is intentionally provocative.
-Its goal is to document limitations of existing json parsers, not to denigrate the work of the many contributors who worked on the various libraries presented here.
+Documenting how JSON parsers of several programming languages deal with deeply nested structures.
 
 ## Introduction
 
@@ -13,11 +11,13 @@ This is very convenient while programming the parser, but it has consequences on
 indeed, the size of the [call stack](https://en.wikipedia.org/wiki/Call_stack) is usually limited to a value several orders of magnitude smaller
 than the available RAM, and this implies that a program with too many levels of recursion will fail.
 
-However, the [JSON specification](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)
-doesn't contain any limit on how deeply nested JSON structures can be.
-This means that most JSON parsers fail on a valid input.
+The two most recent JSON standards [RFC 8259](https://tools.ietf.org/html/rfc8259) and [RFC 7159](https://tools.ietf.org/html/rfc7159) both say "An implementation may set limits on the maximum depth of nesting". 
+However, the [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf) specification
+doesn't contain any limit on how deeply nested JSON structures can be. 
 
-This repository contains tools to measure the limits of JSON parsers of different languages.
+This means that there is not a defined level of nesting which is correct or incorrect with regard to the JSON specification, and JSON parsers may differ when parsing nested structures.
+
+This repository contains tools to measure the nesting limits of JSON parsers of different languages.
 
 ## How to use
 
@@ -33,23 +33,23 @@ It uses [binary search](https://en.wikipedia.org/wiki/Binary_search_algorithm) t
 ## Results
 
 On my machine (Ubuntu Linux 4.10.0-35-generic SMP x86_64 with 8Gb RAM, 8.4 MB maximum stack size),
-I found the following results, sorted from worst to best:
+I found the following results, sorted from least nesting to most nesting:
 
-language        | json library                                                | nesting level | file size     | notes                         |
-----------------| ----------------------------------------------------------- | ------------- | ------------- | ----------------------------- |
-ruby            | [json](https://rubygems.org/gems/json/versions/1.8.3)       | 101           | 202 bytes     |
-rust            | [serde_json](https://docs.serde.rs/serde_json/)             | 128           | 256 bytes     |
-php             | `json_decode`                                               | 512           | 1024 bytes    | maximum depth is configurable |
-python3         | [json](https://docs.python.org/3/library/json.html)         | 994           | 2.0 KB        | without sys.setrecursionlimit
-C               | [jansson](https://jansson.readthedocs.io/)                  | 2049          | 4.0 KB        | 
-java - gson     | [Gson](https://github.com/google/gson)                      | 5670          | 11.3 KB       |
-javascript      | `JSON.parse`                                                | 5713          | 11.4 KB       |
-java - jackson  | [Jackson](https://github.com/FasterXML/jackson-core)        | 6373          | 13   KB       |
-C++             | [nlohmann::json](https://github.com/nlohmann/json)          | 13787         | 27.6 KB       | segfault
-Nim             | [json](https://nim-lang.org/docs/json.html)                 | 100000        | 200 KB        | w/ `-d:release`
-go              | `encoding/json`                                             | 2581101       | 5.0 MiB       | goroutine stack exceeds 1000000000-byte limit
-ruby            | [Oj](https://github.com/ohler55/oj)                         | ∞             | ∞             |
-Haskell         | [Aeson](https://hackage.haskell.org/package/aeson)          | ∞             | ∞             | available RAM is the only limit
+language   | json library                                                | nesting level | file size     | notes                         |
+---------- | ----------------------------------------------------------- | ------------- | ------------- | ----------------------------- |
+ruby       | [json](https://rubygems.org/gems/json/versions/1.8.3)       | 101           | 202 bytes     |
+rust       | [serde_json](https://docs.serde.rs/serde_json/)             | 128           | 256 bytes     |
+php        | `json_decode`                                               | 512           | 1024 bytes    | maximum depth is configurable |
+python3    | [json](https://docs.python.org/3/library/json.html)         | 994           | 2.0 KB        | without sys.setrecursionlimit
+C          | [jansson](https://jansson.readthedocs.io/)                  | 2049          | 4.0 KB        | 
+java       | [Gson](https://github.com/google/gson)                      | 5670          | 11.3 KB       |
+javascript | `JSON.parse`                                               | 5713          | 11.4 KB       |
+C++        | [nlohmann::json](https://github.com/nlohmann/json)          | 13787         | 27.6 KB       | segfault
+Nim        | [json](https://nim-lang.org/docs/json.html)                 | 100000        | 200 KB        | w/ `-d:release`
+go         | `encoding/json`                                             | 2581101       | 5.0 MiB       | goroutine stack exceeds 1000000000-byte limit
+ruby       | [Oj](https://github.com/ohler55/oj)                         | ∞             | ∞             |
+Haskell    | [Aeson](https://hackage.haskell.org/package/aeson)          | ∞             | ∞             | available RAM is the only limit
+
 
 ## Remarks
 


### PR DESCRIPTION
Discussing only ECMA-404 is misleading, so I've adjusted the wording to more accurately reflect the JSON specification.