### PR TITLE
Make the rust parser only dependent on available stack size

### DIFF
--- a/parser_rust/Cargo.toml
+++ b/parser_rust/Cargo.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 authors = ["Ophir LOJKINE <pere.jobs@gmail.com>"]
 
 [dependencies]
-serde_json = "1.0"
+serde_json = {version = "1.0", features = ["unbounded_depth"] }
+serde = "1.0"
+serde_stacker = "0.1"

--- a/parser_rust/src/main.rs
+++ b/parser_rust/src/main.rs
@@ -1,8 +1,49 @@
 extern crate serde_json;
+extern crate serde;
+extern crate serde_stacker;
 
-use serde_json::{Value};
+use serde::de::Deserialize;
+use serde_json::{Deserializer, Value};
 
 fn main() {
-    let v: Value = serde_json::from_reader(std::io::stdin()).unwrap();
-    println!("{}", v);
+    let mut d = Deserializer::from_reader(std::io::stdin());
+    d.disable_recursion_limit();
+    let d = serde_stacker::Deserializer::new(&mut d);
+    let v: Value = Value::deserialize(d).unwrap();
+    print_value(&v);
+
+    carefully_drop_nested_arrays(v);
+}
+
+fn print_value(mut v: &Value) {
+    let mut level = 0;
+    let mut stack = vec![value];
+    while let Some(value) = stack.pop() {
+        match value {
+            Value::Array(array) => {
+                if array.len() > 1 {
+                    unimplemented!()
+                }
+                level += 1;
+                stack.extend(array);
+            }
+            _ => unimplemented!(),
+        }
+    }
+    for _ in 0..level {
+        print!("[");
+    }
+    for _ in 0..level {
+        print!("]");
+    }
+    println!();
+}
+
+fn carefully_drop_nested_arrays(value: Value) {
+    let mut stack = vec![value];
+    while let Some(value) = stack.pop() {
+        if let Value::Array(array) = value {
+            stack.extend(array);
+        }
+    }
 }


### PR DESCRIPTION
This makes the Rust parser only dependent on the maximum stack size set by the system. On GNU/Linux, you can view it via the `ulimit -all` command and set it via `ulimit -s `.