### PR TITLE
Set the JVM Stack Size to 8.4M, add CI & update readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,14 @@ matrix:
       install: go build parser_go.go
       script: ./test_parser.sh ./parser_go
 
+    - language: java
+      jdk: openjdk12
+      script:
+        - mvn -f parser-java-jackson/pom.xml clean install -DskipTests
+        - ./test_parser.sh java -Xss8400k -jar parser-java-jackson/target/bad-parser-jackson-1.0-SNAPSHOT.jar
+      cache:
+        directories:
+          - $HOME/.m2
 
     # nim
     - language: c

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ python3         | [json](https://docs.python.org/3/library/json.html)         | 
 C               | [jansson](https://jansson.readthedocs.io/)                  | 2049          | 4.0 KB        | 
 java - gson     | [Gson](https://github.com/google/gson)                      | 5670          | 11.3 KB       |
 javascript      | `JSON.parse`                                                | 5713          | 11.4 KB       |
-java - jackson  | [Jackson](https://github.com/FasterXML/jackson-core)        | 6373          | 13   KB       |
 C++             | [nlohmann::json](https://github.com/nlohmann/json)          | 13787         | 27.6 KB       | segfault
+java - jackson  | [Jackson](https://github.com/FasterXML/jackson-core)        | 40000         | 79 KB         | w/ -Xss8400k (JVM Stack size)
 Nim             | [json](https://nim-lang.org/docs/json.html)                 | 100000        | 200 KB        | w/ `-d:release`
 go              | `encoding/json`                                             | 2581101       | 5.0 MiB       | goroutine stack exceeds 1000000000-byte limit
 ruby            | [Oj](https://github.com/ohler55/oj)                         | ∞             | ∞             |

--- a/parser-java-jackson/src/main/java/com/github/lovasoa/jsonlimits/JacksonJavaParser.java
+++ b/parser-java-jackson/src/main/java/com/github/lovasoa/jsonlimits/JacksonJavaParser.java
@@ -1,20 +1,19 @@
 package com.github.lovasoa.jsonlimits;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Objects;
-import java.util.Scanner;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JacksonJavaParser {
 
-    private static final Scanner SIN = new Scanner(System.in);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    public static void main(String[] args) throws JsonProcessingException {
-        String fullInput = SIN.next();
-        System.out.println("Full input: " + fullInput);
-        JsonNode jsonTree = new ObjectMapper().readTree(fullInput);
+    public static void main(String[] args) throws IOException {
+        JsonNode jsonTree = OBJECT_MAPPER.readTree(new BufferedReader(new InputStreamReader(System.in)));
         Objects.requireNonNull(jsonTree);
     }
 

--- a/parser_java_jackson.sh
+++ b/parser_java_jackson.sh
@@ -3,4 +3,4 @@
 # Assumes maven on path configured with Java 11+
 mvn -f parser-java-jackson/pom.xml clean install -DskipTests
 
-./test_parser.sh "$JAVA_HOME"/bin/java -jar parser-java-jackson/target/bad-parser-jackson-1.0-SNAPSHOT.jar
+./test_parser.sh "$JAVA_HOME"/bin/java -Xss8400k -jar parser-java-jackson/target/bad-parser-jackson-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Turns out the JVM doesn't set its application stack size to that of the kernel automatically, so update that to match the 8.4M you mention in the readme + slight call performance improvement